### PR TITLE
fix: protect dashboard routes with Clerk middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,12 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher([
+  '/dashboard(.*)',
+])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect()
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Add route protection for /dashboard and all subpages to prevent unauthorized access. This resolves the 'Unauthorized' error when accessing dashboard while logged out.

Fixes #6